### PR TITLE
feat(init): no stop of service if source or resource dir is empty

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,8 @@ ADDED:
 
 CHANGED:
   - La documentation de l'API d'administration a été grandement enrichie. 
-  - La route /health a une réponse plus complète et est vraiment codée pour prendre en compte l'état de chaque service et chaque source disponibles. 
+  - La route /health a une réponse plus complète et est vraiment codée pour prendre en compte l'état de chaque service et chaque source disponibles.
+  - Les dossiers de sources et de resources des services peuvent maintenant être vide à l'initialisation. 
 
 ## 2.0.0
 

--- a/documentation/developers/concepts.md
+++ b/documentation/developers/concepts.md
@@ -144,9 +144,11 @@ Ce service est l'objet qui permet de gérer les ressources proposées par l'inst
 
 Chaque ressource contient plusieurs sources. Étant donné que plusieurs ressources peuvent pointer vers des sources communes, le service contient un catalogue de sources uniques et un manager de ces sources.
 
-Lorsque l'application est lancée, on commence par lire la configuration de l'application pour être capable d'instancier le logger. Une fois que le logger est chargé, on vérifie complètement la configuration.
+Lorsque l'application est lancée, on commence par lire la configuration de l'application pour être capable d'instancier le logger. 
 
-Après cela, on charge les ressources et les sources du service indiquées dans la configuration. C'est à ce moment que les fichiers sont lus, stockés en RAM si nécessaire, et que les connexions aux bases de données sont effectuées. 
+Une fois que le logger est chargé, on vérifie complètement la configuration. Il est possible de configurer un service avec des dossiers de sources et de ressources vides. Ils pourront être remplis plus tard. Cependant, ces dossier doivent être indiqués lors de la configuration du service. 
+
+Après cela, on charge les ressources et les sources du service indiquées dans la configuration s'il y en a. C'est à ce moment que les fichiers sont lus, stockés en RAM si nécessaire, et que les connexions aux bases de données sont effectuées. 
 
 Enfin, on finit par charger les APIs exposées par le service. C'est là qu'ExpressJS crée le ou les serveurs Node et charge les routes disponibles.  
 

--- a/src/js/resources/resourceManager.js
+++ b/src/js/resources/resourceManager.js
@@ -87,7 +87,7 @@ module.exports = class resourceManager {
       }
 
       if (fileList.length === 0) {
-        LOGGER.warn("Le dossier " + directory + " est vide");
+        LOGGER.warn("Le dossier des resources est vide '" + directory + "'");
         return true;
       }
 

--- a/src/js/resources/resourceManager.js
+++ b/src/js/resources/resourceManager.js
@@ -88,7 +88,7 @@ module.exports = class resourceManager {
 
       if (fileList.length === 0) {
         LOGGER.warn("Le dossier " + directory + " est vide");
-        return false;
+        return true;
       }
 
       for (let i = 0; i < fileList.length; i++) {

--- a/src/js/sources/sourceManager.js
+++ b/src/js/sources/sourceManager.js
@@ -176,7 +176,7 @@ module.exports = class sourceManager {
 
       if (fileList.length === 0) {
         LOGGER.warn("Le dossier " + directory + " est vide");
-        return false;
+        return true;
       }
 
       for (let i = 0; i < fileList.length; i++) {
@@ -1005,8 +1005,8 @@ module.exports = class sourceManager {
     LOGGER.info("Connexion de l'ensemble des sources...");
 
     if (this._loadedSourceId.length === 0) {
-      LOGGER.error("Aucune source n'est disponible");
-      return false;
+      LOGGER.warn("Aucune source n'est disponible");
+      return true;
     }
 
     try {

--- a/src/js/sources/sourceManager.js
+++ b/src/js/sources/sourceManager.js
@@ -175,7 +175,7 @@ module.exports = class sourceManager {
       }
 
       if (fileList.length === 0) {
-        LOGGER.warn("Le dossier " + directory + " est vide");
+        LOGGER.warn("Le dossier des sources est vide '" + directory + "'");
         return true;
       }
 

--- a/test/functional/configuration/cucumber/features/conf-service.feature
+++ b/test/functional/configuration/cucumber/features/conf-service.feature
@@ -396,6 +396,14 @@ Feature: Road2 service configuration
     Then the configuration analysis should give an exit code 1
     Then the server log should contain "Mauvaise configuration: Champ 'application:resources:directories' manquant !"
 
+  Scenario: [service.json] (resources.directories sans aucune resource)
+    Given a valid configuration 
+    And an empty directory "empty_resource"
+    And with parameter "empty_resource" for attribute "application.resources.directories.[0]" in service configuration
+    When I test the configuration
+    Then the configuration analysis should give an exit code 0
+    Then the server log should contain "Le dossier des resources est vide"
+
   # TODO 
   # Tester un dossier de ressources dont une des ressources ne peut être lues 
 
@@ -466,6 +474,14 @@ Feature: Road2 service configuration
     When I test the configuration
     Then the configuration analysis should give an exit code 1
     Then the server log should contain "Mauvaise configuration: Champ 'application:sources:directories' manquant !"
+
+  Scenario: [service.json] (sources.directories sans aucune sources)
+    Given a valid configuration 
+    And an empty directory "empty_sources"
+    And with parameter "empty_sources" for attribute "application.sources.directories.[0]" in service configuration
+    When I test the configuration
+    Then the configuration analysis should give an exit code 0
+    Then the server log should contain "Le dossier des sources est vide"
 
   # TODO 
   # Tester un dossier de ressources dont une des ressources ne peut être lues 

--- a/test/functional/configuration/cucumber/features/conf-service.feature
+++ b/test/functional/configuration/cucumber/features/conf-service.feature
@@ -363,7 +363,7 @@ Feature: Road2 service configuration
     Given a valid configuration 
     And with parameter "test" for attribute "application.resources.directories.[1]" in service configuration
     When I test the configuration
-    Then the configuration analysis should give an exit code 0
+    Then the configuration analysis should give an exit code 1
     Then the server log should contain "Mauvaise configuration: Le dossier n'existe pas:"
 
     Scenario: [service.json] (resources.directories sur deux dossiers qui n'existent pas et en chemins relatifs)
@@ -442,7 +442,7 @@ Feature: Road2 service configuration
     Given a valid configuration 
     And with parameter "test" for attribute "application.sources.directories.[1]" in service configuration
     When I test the configuration
-    Then the configuration analysis should give an exit code 0
+    Then the configuration analysis should give an exit code 1
     Then the server log should contain "Mauvaise configuration: Le dossier n'existe pas:"
 
     Scenario: [service.json] (sources.directories sur deux dossiers qui n'existent pas et en chemins relatifs)
@@ -480,8 +480,18 @@ Feature: Road2 service configuration
     And an empty directory "empty_sources"
     And with parameter "empty_sources" for attribute "application.sources.directories.[0]" in service configuration
     When I test the configuration
-    Then the configuration analysis should give an exit code 0
+    Then the configuration analysis should give an exit code 1
     Then the server log should contain "Le dossier des sources est vide"
+    Then the server log should contain "La ressource contient une source non disponible"
+
+  Given a valid configuration 
+    And an empty directory "empty_resource"
+    And with parameter "empty_resource" for attribute "application.resources.directories.[0]" in service configuration
+    And an empty directory "empty_sources"
+    And with parameter "empty_sources" for attribute "application.sources.directories.[0]" in service configuration
+    When I test the configuration
+    Then the configuration analysis should give an exit code 0
+    Then the server log should contain "Le dossier des resources est vide"
 
   # TODO 
   # Tester un dossier de ressources dont une des ressources ne peut être lues 

--- a/test/functional/configuration/cucumber/features/support/steps.js
+++ b/test/functional/configuration/cucumber/features/support/steps.js
@@ -133,7 +133,7 @@ When("I test the configuration", function(done) {
 });
 
 Then("the configuration analysis should give an exit code {int}", function(code) {
-    assert.equal(this.verifyCommandExitCode(code), true);
+    assert.equal(this.returnCommandExitCode(), code);
 });
 
 Then("the server log should contain {string}", function(message) {

--- a/test/functional/configuration/cucumber/features/support/steps.js
+++ b/test/functional/configuration/cucumber/features/support/steps.js
@@ -50,6 +50,10 @@ Given("a file {string} non readable", function(relativeFilePath) {
     this.createFile(relativeFilePath, "", false);
 });
 
+Given("an empty directory {string}", function(dirname) {
+    this.createDir(dirname);
+});
+
 Given("a server configuration non readable", function() {
     this.nonReadableServerConfiguration();
 });

--- a/test/functional/configuration/cucumber/features/support/world.js
+++ b/test/functional/configuration/cucumber/features/support/world.js
@@ -491,6 +491,16 @@ class road2World {
 
     }
 
+    // Creation de répertoire
+    createDir(dirname) {
+        try {
+            fs.mkdirSync(path.join(this._tmpDirConf, dirname));
+        } catch(error) {
+            throw "Can't create directory " + dirname + " : " + error;
+        }
+        return true
+    }
+
     createWrongJSONFile(relativeFilePath) {
 
         try {

--- a/test/functional/configuration/cucumber/features/support/world.js
+++ b/test/functional/configuration/cucumber/features/support/world.js
@@ -641,15 +641,11 @@ class road2World {
         
     }
 
-    // Analyse du code de retour de la commande 
-    verifyCommandExitCode(code) {
+    // Retourne le code de la commande 
+    returnCommandExitCode() {
         
-        if (code === this._code) {
-            return true;
-        } else {
             return this._code;
-        }
-
+        
     }
 
     // Analyse des logs 


### PR DESCRIPTION
### Need 
For a better administration, a service could be loaded without any sources or resources. 

### Functionalities 

- The service configuration has to contain a directory for sources et another for resources but those can be empty and road2 will not raise any error (only a warning). 

### Tasks 

- [x] Code it 
- [x] Modify tests inside `test/functional/configuration/cucumber/features/conf-service.feature`
- [x] Run tests inside docker (rtest, ctest, utest, itest)
- [x] Update docs (ex. functionalities.md, changelog.md)