### PR TITLE
[del] onStart option and feature

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 2.2.0
+
+DELETED:
+  - option onStart inside admin configuration is deleted 
+
 ## 2.1.0
 
 CHANGED:

--- a/changelog.md
+++ b/changelog.md
@@ -1,15 +1,13 @@
 # CHANGELOG
 
-## 2.2.0
-
-DELETED:
-  - option onStart inside admin configuration is deleted 
-
 ## 2.1.0
 
 CHANGED:
   - La documentation de l'API d'administration a été grandement enrichie. 
   - La route /health a une réponse plus complète et est vraiment codée pour prendre en compte l'état de chaque service et chaque source disponibles. 
+
+DELETED:
+  - option onStart inside admin configuration is deleted 
 
 ## 2.0.0
 

--- a/docker/config/road2.json
+++ b/docker/config/road2.json
@@ -8,7 +8,6 @@
       {
         "id": "main",
         "configuration": "/home/docker/config/service.json",
-        "onStart": "true",
         "creationType": "newProcess" 
       }
     ],

--- a/documentation/apis/administration/1.0.0/api.yaml
+++ b/documentation/apis/administration/1.0.0/api.yaml
@@ -779,9 +779,6 @@ components:
                   configuration: 
                     type: "string"
                     example: "/home/docker/config/service.json"
-                  onStart: 
-                    type: "string"
-                    example: "true"
                   creationType: 
                     type: "string"
                     example: "newProcess"

--- a/documentation/configuration/administration/admin_model.yaml
+++ b/documentation/configuration/administration/admin_model.yaml
@@ -34,10 +34,6 @@
 					"configuration":
 						type: string
 						required: true
-					# Indiquer si on souhaite que le service soit démarré au lancement de l'admin
-					"onStart":
-						type: string
-						required: true
 					# Type de création du service. Pour le moment, il seul 'newProcess' est accepté. On crée un nouveau processus pour le service. 
 					"creationType":
 						type: string

--- a/documentation/developers/concepts.md
+++ b/documentation/developers/concepts.md
@@ -128,7 +128,7 @@ Le premier point d'entrée possible est le fichier `src/js/road2.js`. Ce fichier
 
 Cet administrateur permet plusieurs choses : 
 - On peut le lancer uniquement pour vérifier la bonne configuration de l'administrateur et des services associés. Dans ce cas là, le processus s'éteint après la vérification et renvoie un code d'erreur permettant de déterminer s'il y a eu un problème et son type. 
-- On peut le lancer en mode serveur pour administrer un ou plusieurs services via une API HTTP(S). Dans ce cas là, il est possible de lui demander de lancer les service à son démarrage. Il sera aussi possible de les démarrer plus tard. 
+- On peut le lancer en mode serveur pour administrer un ou plusieurs services via une API HTTP(S). Dans ce cas là, l'administrateur va lancer tous les services déjà configurés. Il sera aussi possible d'en créer d'autres plus tard. 
 
 Un administrateur a été créé pour réaliser des tâches qui auraient gêné la bonne exécution du service. 
 

--- a/src/js/administrator/administrator.js
+++ b/src/js/administrator/administrator.js
@@ -205,22 +205,6 @@ module.exports = class Administrator {
     
             }
     
-            if (!curServiceConf.onStart) {
-                LOGGER.error("Mauvaise configuration: 'onStart' absent.");
-                return false;
-            } else {
-    
-                LOGGER.debug("configuration.onStart présent");
-    
-                if (curServiceConf.onStart !== "true" && curServiceConf.onStart !== "false") {
-                    LOGGER.error("Mauvaise configuration: 'onStart' doit être 'true' ou 'false'.");
-                    return false;
-                } else {
-                    LOGGER.debug("configuration.onStart bien configuré");
-                }
-    
-            }
-    
             if (!curServiceConf.creationType) {
                 LOGGER.error("Mauvaise configuration: 'creationType' absent.");
                 return false;
@@ -422,30 +406,21 @@ module.exports = class Administrator {
     /**
      *
      * @function
-     * @name createServicesOnStart
-     * @description Création des services gérés par cet administrateur dont la création a été demandé au démarrage de l'administrateur
+     * @name createServices
+     * @description Création des services gérés par cet administrateur 
      *
      */
 
-    async createServicesOnStart() {
+    async createServices() {
 
-        LOGGER.info("Vérification et création des services onStart=true...");
+        LOGGER.info("Vérification et création des services");
 
-        // Pour chaque service, on va voir s'il doit être démarré 
-        // Si oui, on vérifie sa configuration puis on le démarre 
+        // Pour chaque service, on vérifie sa configuration puis on le démarre 
 
         for (let i = 0; i < this._configuration.administration.services.length; i++) {
 
             let curIASConf = this._configuration.administration.services[i];
             LOGGER.debug("Analyse du service : " + curIASConf.id);
-
-            if (curIASConf.onStart === "false") {
-                // il n'y a rien à faire
-                LOGGER.debug("Le service " + curIASConf.id + " n'est à démarrer tout de suite");
-                continue;
-            } else {
-                LOGGER.info("Le service " + curIASConf.id + " est à démarrer");
-            }
 
             // Récupération de la configuration
             LOGGER.info("Récupération de la configuration du service");

--- a/src/js/road2.js
+++ b/src/js/road2.js
@@ -62,13 +62,13 @@ async function start() {
         LOGGER.debug("Serveur administrateur créé");
 
         // Création des services au démarrage si demandé
-        LOGGER.info("Création des services demandés au démarrage...");
+        LOGGER.info("Création des services...");
 
-        if (!(await administrator.createServicesOnStart())) {
-          LOGGER.error("Problèmes lors du démarrage des services demandés. Reconfigurez les et relancez leur démarrage.");
+        if (!(await administrator.createServices())) {
+          LOGGER.error("Problèmes lors du démarrage des services. Reconfigurez les et relancez leur démarrage.");
           // On n'éteint pas le serveur d'administration car les services pourront être reconfiguré et démarrés par l'API
         } else {
-          LOGGER.info("Les services concernés ont été démarré");
+          LOGGER.info("Les services ont été démarré");
         }
 
       }

--- a/test/integration/mocha/config/road2.json
+++ b/test/integration/mocha/config/road2.json
@@ -8,7 +8,6 @@
       {
         "id": "main",
         "configuration": "./service.json",
-        "onStart": "true",
         "creationType": "newProcess" 
       }
     ],


### PR DESCRIPTION
onStart is an option and a feature inside the administrator configuration. It allows a service to be configured but not load at the beginning. But it is not really useful and the code is more complex. Deleting this feature allows a simpler code. It is still possible to load an administrator withtout any services and create them later.  