### PR TITLE
feat(projection): add route to get projection from service

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ ADDED:
   - Ajout de la route GET /admin/1.0.0/services dans l'API d'administration
   - Ajout de la route GET /admin/1.0.0/services/{service} dans l'API d'administration
   - Ajout de la route GET /admin/1.0.0/services/{service}/restart dans l'API d'administration
+  - Ajout de la route GET /admin/1.0.0/services/{service}/projections/{projection} dans l'API d'administration
   - Ajout de la route GET /admin/1.0.0/configuration dans l'API d'administration
   - Il est maintenant possible démarrer un administrateur sans services pré-configurés
 

--- a/documentation/apis/administration/1.0.0/api.yaml
+++ b/documentation/apis/administration/1.0.0/api.yaml
@@ -390,7 +390,55 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/errorResponse"
-             
+
+  /services/{service}/projections/{projection}:
+    get:
+      tags:
+      - "Gestion des services"
+      - "Projection"
+      summary: "Récupération d'une projection supportée par un service."
+      description: |
+        Cette requête retourne une projection supportée par un service.
+      operationId: "get-service-projection"
+      parameters:
+      - name: "service"
+        description: "Id du service concerné"
+        in: "path"
+        required: true
+        schema:
+          type: "string"      
+      - name: "projection"
+        description: "Id de la projection concernée"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/projectionConfiguration"
+        400:
+          description: "Invalid parameters"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorResponse"
+        404:
+          description: "Not found"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorResponse"
+        500:
+          description: "Internal server error"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/errorResponse"
+
   /services/{service}/resources:
     get:
       tags:
@@ -953,6 +1001,14 @@ components:
                   version: 
                     type: "string"
                     example: "1.0.0"
+
+    projectionConfiguration:
+      type: "object"
+      properties:
+        id:
+          type: "string"
+          example: "EPSG:4326"
+          required: true
     
     resourceConfiguration:
       type: "object"

--- a/src/js/administrator/administrator.js
+++ b/src/js/administrator/administrator.js
@@ -482,6 +482,7 @@ module.exports = class Administrator {
      * @description Gestion de la requête pour une route d'administration sur un serveur 
      * @param {string} serviceId - Id du service selon l'administrateur
      * @param {object} request - Instance fille de la classe Request 
+     * @return {object} responses - Json contenant la réponse du service à la requête
      *
      */
 

--- a/src/js/administrator/administrator.js
+++ b/src/js/administrator/administrator.js
@@ -478,6 +478,24 @@ module.exports = class Administrator {
     /**
      *
      * @function
+     * @name computeRequest
+     * @description Gestion de la requête pour une route d'administration sur un serveur 
+     * @param {string} serviceId - Id du service selon l'administrateur
+     * @param {object} request - Instance fille de la classe Request 
+     *
+     */
+
+    async computeRequest(serviceId, request) {
+
+        LOGGER.info("computeRequest...");
+        LOGGER.debug("Compute request pour le service : " + serviceId);
+        const response = await this._serviceManager.computeRequest(serviceId, request);
+        return response;
+    }
+
+    /**
+     *
+     * @function
      * @name computeHealthRequest
      * @description Gestion de la requête d'état du serveur 
      * Cette fonction ne suit pas le m$eme chemin que les autres car elle est globale 

--- a/src/js/apis/admin/1.0.0/controller/controller.js
+++ b/src/js/apis/admin/1.0.0/controller/controller.js
@@ -4,6 +4,7 @@ const errorManager = require('../../../../utils/errorManager');
 const log4js = require('log4js');
 const HealthRequest = require('../../../../requests/healthRequest');
 const ServiceRequest = require('../../../../requests/serviceRequest');
+const ProjectionRequest = require('../../../../requests/projectionRequest');
 
 var LOGGER = log4js.getLogger("CONTROLLER");
 
@@ -109,6 +110,69 @@ module.exports = {
     const request = new ServiceRequest(parameters.service);
 
     return request;
+
+  },
+
+
+  /**
+  *
+  * @function
+  * @name checkProjectionParameters
+  * @description Vérification des paramètres d'une requête sur /services/{service}/projections/{projection}
+  * @param {object} parameters - ensemble des paramètres de la requête ExpressJS
+  * @return {ProjectionRequest} request - Instance de la classe ProjectionRequest
+  *
+  */
+
+  checkProjectionParameters: function(parameters) {
+
+    LOGGER.debug("checkProjectionParameters()");
+
+    // Service
+    if (!parameters.service) {
+      throw errorManager.createError(" Parameter 'service' is invalid: there is no value", 400);
+    } 
+    
+    if (parameters.service === "") {
+      throw errorManager.createError(" Parameter 'service' is invalid: value should not be empty", 400);
+    }
+
+    // Projection
+    if (!parameters.projection) {
+      throw errorManager.createError(" Parameter 'projection' is invalid: there is no value", 400);
+    } 
+    
+    if (parameters.projection === "") {
+      throw errorManager.createError(" Parameter 'projection' is invalid: value should not be empty", 400);
+    }
+    
+    // TODO : vérifier ici que le service existe (appel à une fonction de la classe administrator)
+
+    const request = new ProjectionRequest(parameters.service, parameters.projection);
+
+    return request;
+
+  },
+  /**
+  *
+  * @function
+  * @name writeProjectionResponse
+  * @description Ré-écriture de la réponse pour une requête sur /services/<service>/projections/<projection>
+  * @param {object} projectionResponse - Instance de la classe ProjectionResponse
+  * @return {object} userResponse - Réponse envoyée à l'utilisateur
+  *
+  */
+
+  writeProjectionResponse: function(projectionResponse) {
+
+    let userResponse = {};
+
+    LOGGER.debug("writeProjectionResponse()");
+
+    // On doit utiliser les attributs avec _ car les méthodes ne sont pas disponible dans le cadre d'une communication IPC
+    userResponse.id = projectionResponse._id;
+
+    return userResponse;
 
   }
 

--- a/src/js/apis/admin/1.0.0/controller/controller.js
+++ b/src/js/apis/admin/1.0.0/controller/controller.js
@@ -101,7 +101,7 @@ module.exports = {
       throw errorManager.createError(" Parameter 'service' is invalid: there is no value", 400);
     } 
     
-    if (parameters.service === "") {
+    if (parameters.service.trim() === "") {
       throw errorManager.createError(" Parameter 'service' is invalid: value should not be empty", 400);
     }
     
@@ -133,7 +133,7 @@ module.exports = {
       throw errorManager.createError(" Parameter 'service' is invalid: there is no value", 400);
     } 
     
-    if (parameters.service === "") {
+    if (parameters.service.trim() === "") {
       throw errorManager.createError(" Parameter 'service' is invalid: value should not be empty", 400);
     }
 
@@ -142,7 +142,7 @@ module.exports = {
       throw errorManager.createError(" Parameter 'projection' is invalid: there is no value", 400);
     } 
     
-    if (parameters.projection === "") {
+    if (parameters.projection.trim() === "") {
       throw errorManager.createError(" Parameter 'projection' is invalid: value should not be empty", 400);
     }
     

--- a/src/js/apis/admin/1.0.0/index.js
+++ b/src/js/apis/admin/1.0.0/index.js
@@ -197,6 +197,50 @@ router.route("/services/:service/restart")
 
   });
 
+// Services/{service}/projections/{projection}
+// Récupérer une projection supportée par un service
+router.route("/services/:service/projections/:projection")
+
+  .get(async function(req, res, next) {
+
+    LOGGER.debug("requete GET sur /admin/1.0.0/services/:service/projections/:projection");
+    LOGGER.debug(req.originalUrl);
+
+    // On récupère l'instance d'Administrator pour répondre aux requêtes
+    let administrator = req.app.get("administrator");
+
+    // on récupère l'ensemble des paramètres de la requête
+    const parameters = req.params;
+    LOGGER.debug(parameters);
+
+    try {     
+
+      // Vérification des paramètres de la requête
+      const projectionRequest = controller.checkProjectionParameters(parameters);
+      LOGGER.debug(projectionRequest);
+      
+      // Envoie à l'administrateur et récupération de l'objet réponse
+      const projectionResponse = await administrator.computeRequest(projectionRequest.service, projectionRequest);
+      LOGGER.debug(projectionResponse);
+
+      // Vérification de l'id retourné (utilisation attribut car communication IPC)
+      if (projectionResponse._id == "") {
+        next(errorManager.createError("Unknown projection", 404));
+      }else{           
+        // Formattage de la réponse
+        const userResponse = controller.writeProjectionResponse(projectionResponse);
+        LOGGER.debug(userResponse);
+
+        res.set('content-type', 'application/json');
+        res.status(200).json(userResponse);
+      }  
+
+    } catch (error) {
+      return next(error);
+    }
+
+  });
+
 // Gestion des erreurs
 // Cette partie doit être placée après la définition des routes normales
 // ---

--- a/src/js/apis/admin/1.0.0/index.js
+++ b/src/js/apis/admin/1.0.0/index.js
@@ -222,18 +222,13 @@ router.route("/services/:service/projections/:projection")
       // Envoie à l'administrateur et récupération de l'objet réponse
       const projectionResponse = await administrator.computeRequest(projectionRequest.service, projectionRequest);
       LOGGER.debug(projectionResponse);
+               
+      // Formattage de la réponse
+      const userResponse = controller.writeProjectionResponse(projectionResponse);
+      LOGGER.debug(userResponse);
 
-      // Vérification de l'id retourné (utilisation attribut car communication IPC)
-      if (projectionResponse._id == "") {
-        next(errorManager.createError("Unknown projection", 404));
-      }else{           
-        // Formattage de la réponse
-        const userResponse = controller.writeProjectionResponse(projectionResponse);
-        LOGGER.debug(userResponse);
-
-        res.set('content-type', 'application/json');
-        res.status(200).json(userResponse);
-      }  
+      res.set('content-type', 'application/json');
+      res.status(200).json(userResponse);        
 
     } catch (error) {
       return next(error);

--- a/src/js/requests/projectionRequest.js
+++ b/src/js/requests/projectionRequest.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const Request = require('./request');
+
+/**
+*
+* @class
+* @name projectionRequest
+* @description Classe modélisant une requête sur une projection d'un service géré par l'administrateur.
+*
+*/
+
+module.exports = class projectionRequest extends Request {
+
+  /**
+  *
+  * @function
+  * @name constructor
+  * @description Constructeur de la classe projectionRequest
+  * @param {string} serviceId - Id du service interrogé
+  * @param {string} projectionId - Id de la projection interrogée
+  *
+  */
+
+  constructor(serviceId, projectionId) {
+
+    super("projection", "projectionRequest");
+
+    // Id du service d'après l'administrateur
+    this._service = serviceId;
+
+    // Id de la projection
+    this._projection = projectionId;
+
+  }
+
+  /**
+  *
+  * @function
+  * @name get service
+  * @description Récupérer service de la requete
+  *
+  */
+  get service() {
+    return this._service;
+  }
+
+  /**
+  *
+  * @function
+  * @name set service
+  * @description Attribuer le service de la requete
+  * @param {string} id - Id du service 
+  *
+  */
+  set service(id) {
+    this._service = id;
+  }
+
+  /**
+  *
+  * @function
+  * @name get projection
+  * @description Récupérer la projection demandée
+  *
+  */
+  get projection() {
+    return this._projection;
+  }
+
+  /**
+  *
+  * @function
+  * @name set projection
+  * @description Attribuer la projection de la requete
+  * @param {string} id - Id de la projection 
+  *
+  */
+  set projection(id) {
+    this._projection = id;
+  }
+
+}

--- a/src/js/responses/projectionResponse.js
+++ b/src/js/responses/projectionResponse.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const Response = require('./response');
+
+/**
+*
+* @class
+* @name projectionResponse
+* @description Classe modélisant une réponse de description d'une projection
+*
+*/
+
+module.exports = class projectionResponse extends Response {
+
+
+  /**
+  *
+  * @function
+  * @name constructor
+  * @description Constructeur de la classe projectionResponse
+  *
+  */
+  constructor() {
+
+    // Type de la réponse 
+    super("projectionResponse");
+
+    // Identifiant
+    this._id = "";
+
+  }
+
+  /**
+  *
+  * @function
+  * @name get id
+  * @description Récupérer l'identifiant
+  *
+  */
+   get id () {
+    return this._id;
+  }
+
+  /**
+  *
+  * @function
+  * @name set id
+  * @description Attribuer l'identifiant
+  * @param {string} id - identifiant
+  *
+  */
+  set id (id) {
+    this._id = id;
+  }
+
+}

--- a/src/js/service/service.js
+++ b/src/js/service/service.js
@@ -16,6 +16,8 @@ const LogManager = require('../utils/logManager');
 const log4js = require('log4js');
 const errorManager = require('../utils/errorManager');
 const HealthResponse = require('../responses/healthResponse');
+const ProjectionResponse = require('../responses/projectionResponse');
+const projectionRequest = require('../requests/projectionRequest');
 
 // Création du LOGGER
 const LOGGER = log4js.getLogger("SERVICE");
@@ -1045,6 +1047,8 @@ module.exports = class Service {
     // Le if est un choix modifiable. Pour le moment c'est ainsi car dans le cas du serviceProcess, on ne peut pas y échapper. 
     if (request._type === "healthRequest") {
       return this.computeHealthRequest(request);
+    }else if (request._type === "projectionRequest") {
+      return this.computeProjectionRequest(request);
     } else {
       throw errorManager.createError("Unknown request type");
     }
@@ -1107,6 +1111,35 @@ module.exports = class Service {
     healthResponse.serviceStates.push(serviceState);
     return healthResponse;
 
+  }
+
+  /**
+  *
+  * @function
+  * @name computeProjectionRequest
+  * @description Fonction utilisée pour connaitre une projection utilisée par un service
+  * @param {projectionRequest} projectionRequest - Instance de la classe projectionRequest 
+  *
+  */
+
+  computeProjectionRequest(projectionRequest) {
+
+    LOGGER.info("computeProjectionRequest...");
+
+    // On doit utiliser les attributs avec _ car les méthodes ne sont pas disponible dans le cadre d'une communication IPC
+    let projectionResponse = new ProjectionResponse();
+    if ( !this._projectionManager.isProjectionLoaded(projectionRequest._projection)){      
+      projectionResponse.id = "";
+      // Le lancement d'exception n'est pas possible car il n'y aura dans ce cas pas de réponse IPC envoyé avec l'uuid de la requete
+      // On envoie donc une réponse avec un id vide pour le traiter comme 404 dans l'administrateur
+      //throw errorManager.createError(`Can't find projection ${projectionRequest._projection}`, 404)
+    }  
+    else{
+
+      projectionResponse.id = projectionRequest._projection;
+    }
+
+    return projectionResponse;
   }
 
 }

--- a/src/js/service/serviceManager.js
+++ b/src/js/service/serviceManager.js
@@ -234,7 +234,7 @@ module.exports = class serviceManager {
         let administeredService = this._loadedServiceAdministeredCatalog[serviceId];
         if (!administeredService) {
             LOGGER.error("Aucun service associé à cet ID: " + serviceId);
-            throw errorManager.createError("Unknown service : " + serviceId);
+            throw errorManager.createError("Unknown service : " + serviceId, 404);
         }
 
         // On envoit la requête et renvoit la réponse 

--- a/src/js/service/serviceProcess.js
+++ b/src/js/service/serviceProcess.js
@@ -203,6 +203,12 @@ module.exports = class ServiceProcess extends ServiceAdministered {
 
             // On attend la réponse et on la renvoit
             let response = await this.waitResponse(request._uuid);
+
+            // On vérifie s'il s'agit d'une erreur
+            if (response._errorFlag) {
+                // TODO : voir si on fait une fonction pour ajouter la récupération de la stack
+                throw errorManager.createError(response.error, response.status)
+            }
             
             return response;
 

--- a/src/js/service/serviceProcess.js
+++ b/src/js/service/serviceProcess.js
@@ -206,8 +206,8 @@ module.exports = class ServiceProcess extends ServiceAdministered {
 
             // On vérifie s'il s'agit d'une erreur
             if (response._errorFlag) {
-                // TODO : voir si on fait une fonction pour ajouter la récupération de la stack
-                throw errorManager.createError(response.error, response.status)
+                // TODO : voir ce qu'on fait de la stack dispo dans response._stack
+                throw errorManager.createError(response._message, response.status);
             }
             
             return response;

--- a/test/functional/request/cucumber/configurations/local-admin.json
+++ b/test/functional/request/cucumber/configurations/local-admin.json
@@ -10,7 +10,8 @@
                 "configuration": "/admin/1.0.0/configuration",
                 "services": "/admin/1.0.0/services",
                 "services/<service>": "/admin/1.0.0/services/<service>",
-                "services/<service>/restart": "/admin/1.0.0/services/<service>/restart"
+                "services/<service>/restart": "/admin/1.0.0/services/<service>/restart",
+                "services/<service>/projections/<projection>": "/admin/1.0.0/services/<service>/projections/<projection>"
             }
         }
     },

--- a/test/functional/request/cucumber/features/req-admin-1.0.0.feature
+++ b/test/functional/request/cucumber/features/req-admin-1.0.0.feature
@@ -144,3 +144,33 @@ Feature: Road2 with data
     When I send the request 
     Then the server should send a response with status 404
     And the response should contain "Can't find service"
+
+  Scenario: [admin/1.0.0] Projection valide du service "main"
+    Given an "GET" request on operation "services/<service>/projections/<projection>" in api "admin" "1.0.0"
+    And with path parameters:
+      | key        | value     |
+      | service    | main      |
+      | projection | EPSG:4326 |
+    When I send the request
+    Then the server should send a response with status 200
+    And the response should have an header "content-type" with value "application/json"
+    And the response should contain "id"
+
+  Scenario: [admin/1.0.0] Projection invalide du service "main"
+    Given an "GET" request on operation "services/<service>/projections/<projection>" in api "admin" "1.0.0"
+    And with path parameters:
+      | key        | value     |
+      | service    | main      |
+      | projection | ftii   |
+    When I send the request
+    Then the server should send a response with status 404
+  
+  Scenario: [admin/1.0.0] Projection invalide du service "main"
+    Given an "GET" request on operation "services/<service>/projections/<projection>" in api "admin" "1.0.0"
+    And with path parameters:
+      | key        | value     |
+      | service    | Unknown      |
+      | projection | Unknown   |
+    When I send the request
+    Then the server should send a response with status 404
+    

--- a/test/functional/request/cucumber/features/req-admin-1.0.0.feature
+++ b/test/functional/request/cucumber/features/req-admin-1.0.0.feature
@@ -172,5 +172,24 @@ Feature: Road2 with data
       | service    | Unknown      |
       | projection | Unknown   |
     When I send the request
-    Then the server should send a response with status 404
+    Then the server should send a response with status 404  
+  
+  Scenario: [admin/1.0.0] Projection sur service non défini
+    Given an "GET" request on operation "services/<service>/projections/<projection>" in api "admin" "1.0.0"
+    And with path parameters:
+      | key        | value     |
+      | service    | %20       |
+      | projection | EPSG:4326 |
+    When I send the request
+    Then the server should send a response with status 400
+
+      
+  Scenario: [admin/1.0.0] Projection non définie sur service "main"
+    Given an "GET" request on operation "services/<service>/projections/<projection>" in api "admin" "1.0.0"
+    And with path parameters:
+      | key        | value     |
+      | service    | main      |
+      | projection | %20       |
+    When I send the request
+    Then the server should send a response with status 400
     

--- a/test/functional/request/cucumber/features/req-admin-1.0.0.feature
+++ b/test/functional/request/cucumber/features/req-admin-1.0.0.feature
@@ -161,7 +161,7 @@ Feature: Road2 with data
     And with path parameters:
       | key        | value     |
       | service    | main      |
-      | projection | ftii   |
+      | projection | unknown   |
     When I send the request
     Then the server should send a response with status 404
   

--- a/test/integration/mocha/requests/integrationProjectionRequest.js
+++ b/test/integration/mocha/requests/integrationProjectionRequest.js
@@ -1,0 +1,41 @@
+const assert = require('assert');
+const ProjectionRequest = require('../../../../src/js/requests/projectionRequest');
+const logManager = require('../logManager');
+
+describe('Test de la classe ProjectionRequest', function() {
+
+  before(function() {
+    // runs before all tests in this block
+    logManager.manageLogs();
+  });
+
+  let request = new ProjectionRequest("test", "EPSG:4326");
+
+  describe('Test du constructeur et des getters/setters', function() {
+
+    it('Get type', function() {
+      assert.equal(request.type, "projectionRequest");
+    });
+
+    it('Get service', function() {
+      assert.equal(request.service, "test");
+    });
+
+    it('Set service', function() {
+        request.service = "main";
+        assert.equal(request.service, "main");
+      });
+    
+
+    it('Get projection', function() {
+      assert.equal(request.projection, "EPSG:4326");
+    });
+
+    it('Set service', function() {
+        request.projection = "EPSG:2154";
+        assert.equal(request.projection, "EPSG:2154");
+      });
+
+  });
+
+});

--- a/test/integration/mocha/responses/integrationProjectionResponse.js
+++ b/test/integration/mocha/responses/integrationProjectionResponse.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+const ProjectionResponse = require('../../../../src/js/responses/projectionResponse');
+const logManager = require('../logManager');
+
+describe('Test de la classe ProjectionResponse', function() {
+
+  before(function() {
+    // runs before all tests in this block
+    logManager.manageLogs();
+  });
+
+  let response = new ProjectionResponse();
+
+  describe('Test du constructeur et des getters/setters', function() {
+
+    it('Get type', function() {
+      assert.equal(response.type, "projectionResponse");
+    });
+
+    it('Get id', function() {
+      assert.equal(response.id, "");
+    });
+
+    it('Set id', function() {
+        response.id = "EPSG:4326";
+        assert.equal(response.id, "EPSG:4326");
+    });
+
+  });
+
+});


### PR DESCRIPTION
closes #63 

# Documentation
- update api.yaml with new route /services/{service}/projections/{projection}
    - for now only returning projection id in response. Waiting for PR for projection params get from projectionManager to add projection param to response

# Code
- add support for error catch for IPC service:
    - add `_uuid` to error before send to catch it in `serviceProcess`
    - add `_errorFlag` to error so `serviceProcess` can define if an error was returned
    - throw error with errorManager
- define new class  `projectionRequest` / `projectionResponse`
- add route inside the router:
    - update controller to check for request param for projection and create projection response
- add new function `computeRequest()` in administrator to pass request to serviceManager
- add `computeProjectionRequest` in service to check wanted projection