### PR TITLE
fix(ci) use x.y.z versionning

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -11,7 +11,7 @@ on:
   push:
     branches: [ "develop" ]
     # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
+    tags: [ '*.*.*' ]
   pull_request:
     branches: [ "develop" ]
 


### PR DESCRIPTION
There was a mistake in the github action for docker build on tag. Only vx.y.z are supported.

The version should be x.y.z.