### PR TITLE
fix(pgr): turf error on some routes (DSR)

### DIFF
--- a/src/js/sources/pgrSource.js
+++ b/src/js/sources/pgrSource.js
@@ -1028,7 +1028,11 @@ module.exports = class pgrSource extends Source {
 
             // On n'enlève les valeurs dupliquées que si la linestring est plus longue que 2 points
             if (currentPgrRouteStep.geometry.coordinates.length > 2) {
-              currentPgrRouteStep.geometry.coordinates = turf.cleanCoords(currentPgrRouteStep.geometry).coordinates
+              try {
+                currentPgrRouteStep.geometry.coordinates = turf.cleanCoords(currentPgrRouteStep.geometry).coordinates;
+              } catch(e) {
+                LOGGER.warn(e);
+              }
             }
           }
 


### PR DESCRIPTION
https://data.geopf.fr/navigation/itineraire?resource=bdtopo-pgr&start=0.725101%2C49.568479&intermediates=0.532261%2C49.698916%7C0.616084%2C49.644273&end=0.403495%2C49.750643&optimization=fastest&crs=EPSG%3A4326&getSteps=true&distanceUnit=kilometer&timeUnit=second&waysAttributes=cpx_gestionnaire

> [2024-04-25T15:00:51.671] [ERROR] SIMPLE 124 - {
  request: '/simple/1.0.0/itineraire?resource=bdtopo-pgr&start=0.725101%2C49.568479&intermediates=0.532261%2C49.698916%7C0.616084%2C49.644273&end=0.403495%2C49.750643&optimization=fastest&crs=EPSG%3A4326&getSteps=true&distanceUnit=kilometer&timeUnit=second&waysAttributes=cpx_gestionnaire',
  query: {
    resource: 'bdtopo-pgr',
    start: '0.725101,49.568479',
    intermediates: '0.532261,49.698916|0.616084,49.644273',
    end: '0.403495,49.750643',
    optimization: 'fastest',
    crs: 'EPSG:4326',
    getSteps: 'true',
    distanceUnit: 'kilometer',
    timeUnit: 'second',
    waysAttributes: 'cpx_gestionnaire'
  },
  body: {},
  error: {
    errorType: undefined,
    message: "Cannot read properties of undefined (reading '0')",
    stack: "TypeError: Cannot read properties of undefined (reading '0')\n" +
      '    at isPointOnLineSegment (/home/docker/app/node_modules/@turf/clean-coords/dist/js/index.js:147:23)\n' +
      '    at cleanLine (/home/docker/app/node_modules/@turf/clean-coords/dist/js/index.js:120:9)\n' +
      '    at Object.cleanCoords (/home/docker/app/node_modules/@turf/clean-coords/dist/js/index.js:35:25)\n' +
      '    at pgrSource.writeRouteResponse (/home/docker/app/src/js/sources/pgrSource.js:1031:63)\n' +
      '    at /home/docker/app/src/js/sources/pgrSource.js:418:32\n' +
      '    at Query.<anonymous> (/home/docker/app/node_modules/pg-pool/index.js:428:18)\n' +
      '    at Query.handleReadyForQuery (/home/docker/app/node_modules/pg/lib/query.js:139:14)\n' +
      '    at Client._handleReadyForQuery (/home/docker/app/node_modules/pg/lib/client.js:301:19)\n' +
      '    at Connection.emit (node:events:513:28)\n' +
      '    at /home/docker/app/node_modules/pg/lib/connection.js:119:12'
  }
}