### PR TITLE
feat(valhalla): allow to configure exec timeout

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.2.8
+ADDED:
+- Valhalla: allow to configure a timeout on valhalla_service exec
+
 ## 2.2.7
 ADDED:
 - Valhalla: Provide the ability to set maxBuffer in exec command options to avoid maxBuffer lenght exceeded error (#109)

--- a/documentation/production/readme.md
+++ b/documentation/production/readme.md
@@ -72,3 +72,7 @@ Road2 peut être directement interrogé en HTTPS. Pour cela, il utilise le modul
 
 Il est possible de changer la taille du buffer lors d'une source Valhalla en valorisant la variable d'environnement `EXEC_MAX_BUFFER_SIZE`.
 La valeur par défaut est de 1MB.
+
+### Gestion du timeout valhalla
+Il est possible de changer la valeur du timeout d'execution du process valhalla_service en valorisant la variable d'environnement `EXEC_TIMEOUT` (nombre de millisecondes).
+La valeur par défaut est `0` soit pas de timeout.

--- a/src/js/sources/valhallaSource.js
+++ b/src/js/sources/valhallaSource.js
@@ -19,6 +19,8 @@ const log4js = require('log4js');
 const LOGGER = log4js.getLogger("VALHALLASOURCE");
 // Récupération de la valeur du maxBuffer en variable d'environment variable ou valorisation par défaut (1MB)
 const maxBuffer = process.env.EXEC_MAX_BUFFER_SIZE ? parseInt(process.env.EXEC_MAX_BUFFER_SIZE, 10) : 1024 * 1024;
+// Récupération de la valeur du timeout pour l'execution du valhalla_service en variable d'environnement ou valorisation par défaut (0)
+const execTimeout = process.env.EXEC_TIMEOUT ? parseInt(process.env.EXEC_TIMEOUT, 10) : 0;
 
 /**
 *
@@ -188,7 +190,7 @@ module.exports = class valhallaSource extends Source {
       // Permet de grandement se simplifier le parsing !!
       const optionsString = `"directions_options":{"format":"osrm"}`;
       const commandString = `valhalla_service ${this._configuration.storage.config} route '{${locationsString},${costingString},${optionsString}}' `;
-      const options = { maxBuffer: maxBuffer };
+      const options = { maxBuffer: maxBuffer, timeout: execTimeout };
       LOGGER.info(commandString);
 
       return new Promise( (resolve, reject) => {
@@ -290,7 +292,7 @@ module.exports = class valhallaSource extends Source {
         const reverseString = `"reverse":${reverse}`;
         const polygonsString = `"polygons":true`;
         const commandString = `valhalla_service ${this._configuration.storage.config} isochrone '{${locationsString},${costingString},${costingOptionsString},${contoursString},${reverseString},${polygonsString}}' `;
-        const options = { maxBuffer: maxBuffer };
+        const options = { maxBuffer: maxBuffer, timeout: execTimeout };
         LOGGER.info(commandString);
 
         return new Promise( (resolve, reject) => {


### PR DESCRIPTION
# Allow to configure a timeout on valhalla_service `exec`

When requesting a valhalla source, if the http request is canceled (client termination or reverse proxy timeout) the `valhalla_service` process continues to run.

The idea is to allow to set a timeout (close to the reverse proxy one) so the process won't continue to run when the underlying http request is already terminated.